### PR TITLE
fix command to run the python script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install requests
 Then run:
 
 ```bash
-python index_articles.py http://localhost:9200/articles ./million.jsonl
+python index_articles.py http://localhost:9200 ./million.jsonl
 ```
 
 #### Term frequencies


### PR DESCRIPTION
As the script expects only base URL on the command, we do not need '/articles' on the command. The index_article.py script adds "/articles/article"  before executing the POST API call, so we do not need '/articles' here.